### PR TITLE
中間テーブル作成

### DIFF
--- a/warm/app/E_l_map.php
+++ b/warm/app/E_l_map.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class E_l_map extends Model
+{
+    //
+}

--- a/warm/app/E_r_map.php
+++ b/warm/app/E_r_map.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class E_r_map extends Model
+{
+    //
+}

--- a/warm/app/E_sbj_map.php
+++ b/warm/app/E_sbj_map.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class E_sbj_map extends Model
+{
+    //
+}

--- a/warm/app/Http/Controllers/E_l_mapsController.php
+++ b/warm/app/Http/Controllers/E_l_mapsController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class E_l_mapsController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+
+     public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/warm/app/Http/Controllers/E_r_mapsController.php
+++ b/warm/app/Http/Controllers/E_r_mapsController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class E_r_mapsController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+
+     public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/warm/app/Http/Controllers/E_sbj_mapsController.php
+++ b/warm/app/Http/Controllers/E_sbj_mapsController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class E_sbj_mapsController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+
+     public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/warm/app/Http/Controllers/S_l_mapsController.php
+++ b/warm/app/Http/Controllers/S_l_mapsController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class S_l_mapsController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+
+     public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/warm/app/Http/Controllers/S_n_mapsController.php
+++ b/warm/app/Http/Controllers/S_n_mapsController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class S_n_mapsController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+
+     public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/warm/app/Http/Controllers/S_sbj_mapsController.php
+++ b/warm/app/Http/Controllers/S_sbj_mapsController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class S_sbj_mapsController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+
+     public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/warm/app/S_l_map.php
+++ b/warm/app/S_l_map.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class S_l_map extends Model
+{
+    //
+}

--- a/warm/app/S_n_map.php
+++ b/warm/app/S_n_map.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class S_n_map extends Model
+{
+    //
+}

--- a/warm/app/S_sbj_map.php
+++ b/warm/app/S_sbj_map.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class S_sbj_map extends Model
+{
+    //
+}

--- a/warm/database/migrations/2020_07_04_114729_create_e_sbj_maps_table.php
+++ b/warm/database/migrations/2020_07_04_114729_create_e_sbj_maps_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateESbjMapsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('e_sbj_maps', function (Blueprint $table) {
+            $table->unsignedInteger('events_id');
+            $table->unsignedInteger('subjects_id');
+            $table->timestamps();
+
+            $table->index('events_id');
+            $table->index('subjects_id');
+
+            $table->unique([
+                'events_id',
+                'subjects_id'
+            ]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('e_sbj_maps');
+    }
+}

--- a/warm/database/migrations/2020_07_04_114956_create_e_r_maps_table.php
+++ b/warm/database/migrations/2020_07_04_114956_create_e_r_maps_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateERMapsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('e_r_maps', function (Blueprint $table) {
+            $table->unsignedInteger('events_id');
+            $table->unsignedInteger('regions_id');
+            $table->timestamps();
+
+            $table->index('events_id');
+            $table->index('regions_id');
+
+            $table->unique([
+                'events_id',
+                'regions_id'
+            ]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('e_r_maps');
+    }
+}

--- a/warm/database/migrations/2020_07_04_115020_create_e_l_maps_table.php
+++ b/warm/database/migrations/2020_07_04_115020_create_e_l_maps_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateELMapsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('e_l_maps', function (Blueprint $table) {
+            $table->unsignedInteger('events_id');
+            $table->unsignedInteger('levels_id');
+            $table->timestamps();
+
+            $table->index('events_id');
+            $table->index('levels_id');
+
+            $table->unique([
+                'events_id',
+                'levels_id'
+            ]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('e_l_maps');
+    }
+}

--- a/warm/database/migrations/2020_07_04_115106_create_s_n_maps_table.php
+++ b/warm/database/migrations/2020_07_04_115106_create_s_n_maps_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateSNMapsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('s_n_maps', function (Blueprint $table) {
+            $table->unsignedInteger('students_id');
+            $table->unsignedInteger('nations_id');
+            $table->timestamps();
+
+            $table->index('students_id');
+            $table->index('nations_id');
+
+            $table->unique([
+                'students_id',
+                'nations_id'
+            ]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('s_n_maps');
+    }
+}

--- a/warm/database/migrations/2020_07_04_115123_create_s_l_maps_table.php
+++ b/warm/database/migrations/2020_07_04_115123_create_s_l_maps_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateSLMapsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('s_l_maps', function (Blueprint $table) {
+            $table->unsignedInteger('students_id');
+            $table->unsignedInteger('levels_id');
+            $table->timestamps();
+
+            $table->index('students_id');
+            $table->index('levels_id');
+
+            $table->unique([
+                'students_id',
+                'levels_id'
+            ]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('s_l_maps');
+    }
+}

--- a/warm/database/migrations/2020_07_04_115208_create_s_sbj_maps_table.php
+++ b/warm/database/migrations/2020_07_04_115208_create_s_sbj_maps_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateSSbjMapsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('s_sbj_maps', function (Blueprint $table) {
+            $table->unsignedInteger('students_id');
+            $table->unsignedInteger('subjects_id');
+            $table->timestamps();
+
+            $table->index('students_id');
+            $table->index('subjects_id');
+
+            $table->unique([
+                'students_id',
+                'subjects_id'
+            ]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('s_sbj_maps');
+    }
+}

--- a/warm/routes/web.php
+++ b/warm/routes/web.php
@@ -40,3 +40,15 @@ Route::resource('students', 'StudentsController');
 Route::resource('subjects', 'SubjectsController');
 
 Route::resource('terms', 'TermsController');
+
+Route::resource('e_sbj_maps', 'E_sbj_mapsController');
+
+Route::resource('e_r_maps', 'E_r_mapsController');
+
+Route::resource('e_l_maps', 'E_l_mapsController');
+
+Route::resource('s_n_maps', 'S_n_mapsController');
+
+Route::resource('s_l_maps', 'S_l_mapsController');
+
+Route::resource('s_sbj_maps', 'S_sbj_mapsController');


### PR DESCRIPTION
中間テーブル作成のための関連ファイル(e_sbj_maps, e_r_maps,e_l_maps, s_n_maps, s_l_maps, s_sbj_maps)
migrate
model
controller
※今回設計で主キーを使わない設計にしています。
これにより同一イベントに同一科目や同一レベルが登録されるのを構造から防いでくれます。

中間テーブル用controller routeを追加
web.php

自分のbranchにpullした後、php artisan migrateを行ってください。